### PR TITLE
Remove method signature from equality check

### DIFF
--- a/core/src/main/java/org/parchmentmc/feather/metadata/AbstractMethodReference.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/AbstractMethodReference.java
@@ -49,8 +49,7 @@ public class AbstractMethodReference implements BaseMethodReference {
         AbstractMethodReference that = (AbstractMethodReference) o;
         return Objects.equals(getOwner(), that.getOwner())
                 && getName().equals(that.getName())
-                && getDescriptor().equals(that.getDescriptor())
-                && Objects.equals(getSignature(), that.getSignature());
+                && getDescriptor().equals(that.getDescriptor());
     }
 
     @Override

--- a/core/src/main/java/org/parchmentmc/feather/metadata/ClassMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/ClassMetadataBuilder.java
@@ -138,9 +138,6 @@ public final class ClassMetadataBuilder implements ClassMetadata {
                                 .withDescriptor(NamedBuilder.create()
                                         .with(mergingScheme, mm.getDescriptor().getName(mergingScheme).orElse(""))
                                 )
-                                .withSignature(NamedBuilder.create()
-                                        .with(mergingScheme, mm.getSignature().getName(mergingScheme).orElse(""))
-                                )
                                 .build(),
                         Function.identity()
                 ));
@@ -156,9 +153,6 @@ public final class ClassMetadataBuilder implements ClassMetadata {
                                 )
                                 .withDescriptor(NamedBuilder.create()
                                         .with(mergingScheme, mm.getDescriptor().getName(mergingScheme).orElse(""))
-                                )
-                                .withSignature(NamedBuilder.create()
-                                        .with(mergingScheme, mm.getSignature().getName(mergingScheme).orElse(""))
                                 )
                                 .build(),
                         Function.identity()

--- a/core/src/main/java/org/parchmentmc/feather/metadata/MethodReferenceBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/MethodReferenceBuilder.java
@@ -107,8 +107,7 @@ public final class MethodReferenceBuilder implements MethodReference {
         MethodReference that = (MethodReference) o;
         return Objects.equals(getOwner(), that.getOwner())
                 && getName().equals(that.getName())
-                && getDescriptor().equals(that.getDescriptor())
-                && Objects.equals(getSignature(), that.getSignature());
+                && getDescriptor().equals(that.getDescriptor());
     }
 
     @Override


### PR DESCRIPTION
This PR removes the method signature from equality checks relating to `MethodReference` and does not set the signature in `MethodReferenceBuilder` anymore when merging methods. This fixes ParchmentMC/Blackstone#3