### PR TITLE
Fix cases were ordering of original collections was not retained when processing data through collectors.

### DIFF
--- a/core/src/main/java/org/parchmentmc/feather/metadata/ClassMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/ClassMetadataBuilder.java
@@ -5,162 +5,145 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.parchmentmc.feather.named.Named;
 import org.parchmentmc.feather.named.NamedBuilder;
 import org.parchmentmc.feather.util.AccessFlag;
+import org.parchmentmc.feather.util.CollectorUtils;
 
-import java.util.*;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public final class ClassMetadataBuilder implements ClassMetadata
-{
-    private Named                         superName              = Named.empty();
-    private LinkedHashSet<Named>          interfaces             = Sets.newLinkedHashSet();
-    private LinkedHashSet<MethodMetadata> methods                = Sets.newLinkedHashSet();
-    private LinkedHashSet<FieldMetadata>  fields                 = Sets.newLinkedHashSet();
-    private LinkedHashSet<ClassMetadata>  innerClasses           = Sets.newLinkedHashSet();
-    private Named                         owner                  = Named.empty();
-    private Named                         name                   = Named.empty();
-    private int                           securitySpecifications = 0;
-    private Named                         signature              = Named.empty();
-    private LinkedHashSet<RecordMetadata> records                = Sets.newLinkedHashSet();
-    private boolean                       isRecord               = false;
+public final class ClassMetadataBuilder implements ClassMetadata {
+    private Named superName = Named.empty();
+    private LinkedHashSet<Named> interfaces = Sets.newLinkedHashSet();
+    private LinkedHashSet<MethodMetadata> methods = Sets.newLinkedHashSet();
+    private LinkedHashSet<FieldMetadata> fields = Sets.newLinkedHashSet();
+    private LinkedHashSet<RecordMetadata> records = Sets.newLinkedHashSet();
+    private LinkedHashSet<ClassMetadata> innerClasses = Sets.newLinkedHashSet();
+    private Named owner = Named.empty();
+    private Named name = Named.empty();
+    private int securitySpecifications = 0;
+    private Named signature = Named.empty();
+    private boolean isRecord = false;
 
-    private ClassMetadataBuilder()
-    {
+    private ClassMetadataBuilder() {
     }
 
-    public static ClassMetadataBuilder create()
-    {
+    public static ClassMetadataBuilder create() {
         return new ClassMetadataBuilder();
     }
 
-    public static ClassMetadataBuilder create(final ClassMetadata classMetadata)
-    {
-        if (classMetadata == null)
-        {
+    public static ClassMetadataBuilder create(final ClassMetadata classMetadata) {
+        if (classMetadata == null) {
             return create();
         }
 
         return create()
-          .withSuperName(classMetadata.getSuperName())
-          .withInterfaces(classMetadata.getInterfaces())
-          .withMethods(classMetadata.getMethods())
-          .withFields(classMetadata.getFields())
-          .withInnerClasses(classMetadata.getInnerClasses())
-          .withOwner(classMetadata.getOwner())
-          .withName(classMetadata.getName())
-          .withSecuritySpecifications(classMetadata.getSecuritySpecification())
-          .withRecords(classMetadata.getRecords())
-          .withIsRecord(classMetadata.isRecord());
+                .withSuperName(classMetadata.getSuperName())
+                .withInterfaces(classMetadata.getInterfaces())
+                .withMethods(classMetadata.getMethods())
+                .withFields(classMetadata.getFields())
+                .withInnerClasses(classMetadata.getInnerClasses())
+                .withOwner(classMetadata.getOwner())
+                .withName(classMetadata.getName())
+                .withSecuritySpecifications(classMetadata.getSecuritySpecification())
+                .withRecords(classMetadata.getRecords())
+                .withIsRecord(classMetadata.isRecord());
     }
 
-    public ClassMetadataBuilder withSuperName(Named superName)
-    {
+    public ClassMetadataBuilder withSuperName(Named superName) {
         this.superName = superName;
         return this;
     }
 
-    public ClassMetadataBuilder withInterfaces(Set<Named> interfaces)
-    {
+    public ClassMetadataBuilder withInterfaces(Set<Named> interfaces) {
         this.interfaces = new LinkedHashSet<>(interfaces);
         return this;
     }
 
-    public ClassMetadataBuilder withMethods(Set<MethodMetadata> methods)
-    {
+    public ClassMetadataBuilder withMethods(Set<MethodMetadata> methods) {
         this.methods = new LinkedHashSet<>(methods);
         return this;
     }
 
-    public ClassMetadataBuilder addMethod(final MethodMetadata method)
-    {
+    public ClassMetadataBuilder addMethod(final MethodMetadata method) {
         this.methods.add(method);
         return this;
     }
 
-    public ClassMetadataBuilder withFields(Set<FieldMetadata> fields)
-    {
+    public ClassMetadataBuilder withFields(Set<FieldMetadata> fields) {
         this.fields = new LinkedHashSet<>(fields);
         return this;
     }
 
-    public ClassMetadataBuilder addField(final FieldMetadata field)
-    {
+    public ClassMetadataBuilder addField(final FieldMetadata field) {
         this.fields.add(field);
         return this;
     }
 
-    public ClassMetadataBuilder withRecords(Set<RecordMetadata> records)
-    {
+    public ClassMetadataBuilder withRecords(Set<RecordMetadata> records) {
         this.records = new LinkedHashSet<>(records);
         this.isRecord = !records.isEmpty();
         return this;
     }
 
-    public ClassMetadataBuilder addRecord(final RecordMetadata record)
-    {
+    public ClassMetadataBuilder addRecord(final RecordMetadata record) {
         this.records.add(record);
         this.isRecord = true;
         return this;
     }
 
-    public ClassMetadataBuilder withInnerClasses(Set<ClassMetadata> innerClasses)
-    {
+    public ClassMetadataBuilder withInnerClasses(Set<ClassMetadata> innerClasses) {
         this.innerClasses = new LinkedHashSet<>(innerClasses);
         return this;
     }
 
-    public ClassMetadataBuilder addInnerClass(final ClassMetadata classMetadata)
-    {
+    public ClassMetadataBuilder addInnerClass(final ClassMetadata classMetadata) {
         this.innerClasses.add(classMetadata);
         return this;
     }
 
-    public ClassMetadataBuilder withOwner(Named owner)
-    {
+    public ClassMetadataBuilder withOwner(Named owner) {
         this.owner = owner;
         return this;
     }
 
-    public ClassMetadataBuilder withName(Named name)
-    {
+    public ClassMetadataBuilder withName(Named name) {
         this.name = name;
         return this;
     }
 
-    public ClassMetadataBuilder withSecuritySpecifications(int securitySpecifications)
-    {
+    public ClassMetadataBuilder withSecuritySpecifications(int securitySpecifications) {
         this.securitySpecifications = securitySpecifications;
         return this;
     }
 
-    public ClassMetadataBuilder withSignature(final Named signature)
-    {
+    public ClassMetadataBuilder withSignature(final Named signature) {
         this.signature = signature;
         return this;
     }
 
-    public ClassMetadataBuilder withIsRecord(final boolean isRecord)
-    {
+    public ClassMetadataBuilder withIsRecord(final boolean isRecord) {
         this.isRecord = isRecord;
         return this;
     }
 
-    public ClassMetadataBuilder merge(final ClassMetadata source, final String mergingScheme)
-    {
-        if (source == null)
-        {
+    public ClassMetadataBuilder merge(final ClassMetadata source, final String mergingScheme) {
+        if (source == null) {
             return this;
         }
 
         this.name = NamedBuilder.create(this.name)
-          .merge(source.getName())
-          .build();
+                .merge(source.getName())
+                .build();
         this.owner = NamedBuilder.create(this.owner)
-          .merge(source.getOwner())
-          .build();
+                .merge(source.getOwner())
+                .build();
         this.superName = NamedBuilder.create(this.superName)
-          .merge(source.getSuperName())
-          .build();
+                .merge(source.getSuperName())
+                .build();
 
         final EnumSet<AccessFlag> thisAccessFlags = AccessFlag.getAccessFlags(this.securitySpecifications);
         final EnumSet<AccessFlag> sourceAccessFlags = AccessFlag.getAccessFlags(source.getSecuritySpecification());
@@ -172,158 +155,142 @@ public final class ClassMetadataBuilder implements ClassMetadata
         this.securitySpecifications = AccessFlag.toSecuritySpecification(mergedFlags);
 
         final Map<Reference, MethodMetadata> schemadLocalMethods = this.methods
-          .stream().collect(Collectors.toMap(
-            mm -> ReferenceBuilder.create()
-              .withName(NamedBuilder.create()
-                .with(mergingScheme, mm.getName().getName(mergingScheme).orElse(""))
-              )
-              .withOwner(NamedBuilder.create()
-                .with(mergingScheme, mm.getOwner().getName(mergingScheme).orElse(""))
-              )
-              .withDescriptor(NamedBuilder.create()
-                .with(mergingScheme, mm.getDescriptor().getName(mergingScheme).orElse(""))
-              )
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        mm -> ReferenceBuilder.create()
+                                .withName(NamedBuilder.create()
+                                        .with(mergingScheme, mm.getName().getName(mergingScheme).orElse(""))
+                                )
+                                .withOwner(NamedBuilder.create()
+                                        .with(mergingScheme, mm.getOwner().getName(mergingScheme).orElse(""))
+                                )
+                                .withDescriptor(NamedBuilder.create()
+                                        .with(mergingScheme, mm.getDescriptor().getName(mergingScheme).orElse(""))
+                                )
+                                .build(),
+                        Function.identity()
+                ));
 
         final Map<Reference, MethodMetadata> schemadSourceMethods = source.getMethods()
-          .stream().collect(Collectors.toMap(
-            mm -> ReferenceBuilder.create()
-              .withName(NamedBuilder.create()
-                .with(mergingScheme, mm.getName().getName(mergingScheme).orElse(""))
-              )
-              .withOwner(NamedBuilder.create()
-                .with(mergingScheme, mm.getOwner().getName(mergingScheme).orElse(""))
-              )
-              .withDescriptor(NamedBuilder.create()
-                .with(mergingScheme, mm.getDescriptor().getName(mergingScheme).orElse(""))
-              )
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        mm -> ReferenceBuilder.create()
+                                .withName(NamedBuilder.create()
+                                        .with(mergingScheme, mm.getName().getName(mergingScheme).orElse(""))
+                                )
+                                .withOwner(NamedBuilder.create()
+                                        .with(mergingScheme, mm.getOwner().getName(mergingScheme).orElse(""))
+                                )
+                                .withDescriptor(NamedBuilder.create()
+                                        .with(mergingScheme, mm.getDescriptor().getName(mergingScheme).orElse(""))
+                                )
+                                .build(),
+                        Function.identity()
+                ));
 
         this.methods = new LinkedHashSet<>();
-        for (final Reference keyReference : schemadLocalMethods.keySet())
-        {
-            if (!schemadSourceMethods.containsKey(keyReference))
-            {
+        for (final Reference keyReference : schemadLocalMethods.keySet()) {
+            if (!schemadSourceMethods.containsKey(keyReference)) {
                 this.methods.add(schemadLocalMethods.get(keyReference));
-            }
-            else
-            {
+            } else {
                 this.methods.add(
-                  MethodMetadataBuilder.create(schemadLocalMethods.get(keyReference))
-                    .merge(schemadSourceMethods.get(keyReference), mergingScheme)
-                    .build()
+                        MethodMetadataBuilder.create(schemadLocalMethods.get(keyReference))
+                                .merge(schemadSourceMethods.get(keyReference), mergingScheme)
+                                .build()
                 );
             }
         }
         schemadSourceMethods.keySet().stream()
-          .filter(mr -> !schemadLocalMethods.containsKey(mr))
-          .forEach(mr -> this.methods.add(schemadSourceMethods.get(mr)));
+                .filter(mr -> !schemadLocalMethods.containsKey(mr))
+                .forEach(mr -> this.methods.add(schemadSourceMethods.get(mr)));
 
         final Map<Named, FieldMetadata> schemadLocalFields = this.fields
-          .stream().collect(Collectors.toMap(
-            fm -> NamedBuilder.create()
-              .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        fm -> NamedBuilder.create()
+                                .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
+                                .build(),
+                        Function.identity()
+                ));
         final Map<Named, FieldMetadata> schemadSourceFields = source.getFields()
-          .stream().collect(Collectors.toMap(
-            fm -> NamedBuilder.create()
-              .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        fm -> NamedBuilder.create()
+                                .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
+                                .build(),
+                        Function.identity()
+                ));
         this.fields = new LinkedHashSet<>();
-        for (final Named keyReference : schemadLocalFields.keySet())
-        {
-            if (!schemadSourceFields.containsKey(keyReference))
-            {
+        for (final Named keyReference : schemadLocalFields.keySet()) {
+            if (!schemadSourceFields.containsKey(keyReference)) {
                 this.fields.add(schemadLocalFields.get(keyReference));
-            }
-            else
-            {
+            } else {
                 this.fields.add(
-                  FieldMetadataBuilder.create(schemadLocalFields.get(keyReference))
-                    .merge(schemadSourceFields.get(keyReference))
-                    .build()
+                        FieldMetadataBuilder.create(schemadLocalFields.get(keyReference))
+                                .merge(schemadSourceFields.get(keyReference))
+                                .build()
                 );
             }
         }
         schemadSourceFields.keySet().stream()
-          .filter(mr -> !schemadLocalFields.containsKey(mr))
-          .forEach(mr -> this.fields.add(schemadSourceFields.get(mr)));
+                .filter(mr -> !schemadLocalFields.containsKey(mr))
+                .forEach(mr -> this.fields.add(schemadSourceFields.get(mr)));
 
         final Map<Named, RecordMetadata> schemadLocalRecords = this.records
-          .stream().collect(Collectors.toMap(
-            fm -> NamedBuilder.create()
-              .with(mergingScheme, fm.getField().getName().getName(mergingScheme).orElse(""))
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        fm -> NamedBuilder.create()
+                                .with(mergingScheme, fm.getField().getName().getName(mergingScheme).orElse(""))
+                                .build(),
+                        Function.identity()
+                ));
         final Map<Named, RecordMetadata> schemadSourceRecords = source.getRecords()
-          .stream().collect(Collectors.toMap(
-            fm -> NamedBuilder.create()
-              .with(mergingScheme, fm.getField().getName().getName(mergingScheme).orElse(""))
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        fm -> NamedBuilder.create()
+                                .with(mergingScheme, fm.getField().getName().getName(mergingScheme).orElse(""))
+                                .build(),
+                        Function.identity()
+                ));
         this.records = new LinkedHashSet<>();
-        for (final Named keyReference : schemadLocalRecords.keySet())
-        {
-            if (!schemadSourceRecords.containsKey(keyReference))
-            {
+        for (final Named keyReference : schemadLocalRecords.keySet()) {
+            if (!schemadSourceRecords.containsKey(keyReference)) {
                 this.records.add(schemadLocalRecords.get(keyReference));
-            }
-            else
-            {
+            } else {
                 this.records.add(
-                  RecordMetadataBuilder.create(schemadLocalRecords.get(keyReference))
-                    .merge(schemadSourceRecords.get(keyReference))
-                    .build()
+                        RecordMetadataBuilder.create(schemadLocalRecords.get(keyReference))
+                                .merge(schemadSourceRecords.get(keyReference))
+                                .build()
                 );
             }
         }
         schemadSourceRecords.keySet().stream()
-          .filter(mr -> !schemadLocalRecords.containsKey(mr))
-          .forEach(mr -> this.records.add(schemadSourceRecords.get(mr)));
+                .filter(mr -> !schemadLocalRecords.containsKey(mr))
+                .forEach(mr -> this.records.add(schemadSourceRecords.get(mr)));
 
         final Map<Named, ClassMetadata> schemadLocalInnerClasses = this.innerClasses
-          .stream().collect(Collectors.toMap(
-            fm -> NamedBuilder.create()
-              .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        fm -> NamedBuilder.create()
+                                .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
+                                .build(),
+                        Function.identity()
+                ));
         final Map<Named, ClassMetadata> schemadSourceInnerClasses = source.getInnerClasses()
-          .stream().collect(Collectors.toMap(
-            fm -> NamedBuilder.create()
-              .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
-              .build(),
-            Function.identity()
-          ));
+                .stream().collect(CollectorUtils.toLinkedMap(
+                        fm -> NamedBuilder.create()
+                                .with(mergingScheme, fm.getName().getName(mergingScheme).orElse(""))
+                                .build(),
+                        Function.identity()
+                ));
         this.innerClasses = new LinkedHashSet<>();
-        for (final Named keyReference : schemadLocalInnerClasses.keySet())
-        {
-            if (!schemadSourceInnerClasses.containsKey(keyReference))
-            {
+        for (final Named keyReference : schemadLocalInnerClasses.keySet()) {
+            if (!schemadSourceInnerClasses.containsKey(keyReference)) {
                 this.innerClasses.add(schemadLocalInnerClasses.get(keyReference));
-            }
-            else
-            {
+            } else {
                 this.innerClasses.add(
-                  ClassMetadataBuilder.create(schemadLocalInnerClasses.get(keyReference))
-                    .merge(schemadSourceInnerClasses.get(keyReference), mergingScheme)
-                    .build()
+                        ClassMetadataBuilder.create(schemadLocalInnerClasses.get(keyReference))
+                                .merge(schemadSourceInnerClasses.get(keyReference), mergingScheme)
+                                .build()
                 );
             }
         }
         schemadSourceInnerClasses.keySet().stream()
-          .filter(mr -> !schemadLocalInnerClasses.containsKey(mr))
-          .forEach(mr -> this.innerClasses.add(schemadSourceInnerClasses.get(mr)));
+                .filter(mr -> !schemadLocalInnerClasses.containsKey(mr))
+                .forEach(mr -> this.innerClasses.add(schemadSourceInnerClasses.get(mr)));
 
         this.signature = NamedBuilder.create(this.signature).merge(source.getSignature()).build();
 
@@ -331,118 +298,103 @@ public final class ClassMetadataBuilder implements ClassMetadata
     }
 
     @Override
-    public @NonNull ClassMetadata toImmutable()
-    {
+    public @NonNull ClassMetadata toImmutable() {
         return build();
     }
 
     @NonNull
-    public ClassMetadata build()
-    {
+    public ClassMetadata build() {
         return new ImmutableClassMetadata(
-          superName.toImmutable(),
-          interfaces.stream().map(Named::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-          methods.stream().map(MethodMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-          fields.stream().map(FieldMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-          records, innerClasses.stream().map(ClassMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-          owner.toImmutable(),
-          name.toImmutable(),
-          securitySpecifications,
-          signature, isRecord);
+                superName.toImmutable(),
+                interfaces.stream().map(Named::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                methods.stream().map(MethodMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                fields.stream().map(FieldMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                records.stream().map(RecordMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                innerClasses.stream().map(ClassMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                owner.toImmutable(),
+                name.toImmutable(),
+                securitySpecifications,
+                signature, isRecord);
     }
 
     @Override
-    public int hashCode()
-    {
-        return Objects.hash(getSuperName(), getInterfaces(), getMethods(), getFields(), getInnerClasses(), getOwner(),
-          getName(), getSecuritySpecification());
+    public int hashCode() {
+        return Objects.hash(getSuperName(), getInterfaces(), getMethods(), getFields(), getRecords(), getInnerClasses(), getOwner(),
+                getName(), getSecuritySpecification());
     }
 
     @Override
-    public boolean equals(Object o)
-    {
-        if (this == o)
-        {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof ClassMetadata))
-        {
+        if (!(o instanceof ClassMetadata)) {
             return false;
         }
         ClassMetadata that = (ClassMetadata) o;
         return getSecuritySpecification() == that.getSecuritySpecification()
-                 && Objects.equals(getSuperName(), that.getSuperName())
-                 && getInterfaces().equals(that.getInterfaces())
-                 && getMethods().equals(that.getMethods())
-                 && getFields().equals(that.getFields())
-                 && getInnerClasses().equals(that.getInnerClasses())
-                 && Objects.equals(getOwner(), that.getOwner())
-                 && getName().equals(that.getName());
+                && Objects.equals(getSuperName(), that.getSuperName())
+                && getInterfaces().equals(that.getInterfaces())
+                && getMethods().equals(that.getMethods())
+                && getFields().equals(that.getFields())
+                && getRecords().equals(that.getRecords())
+                && getInnerClasses().equals(that.getInnerClasses())
+                && Objects.equals(getOwner(), that.getOwner())
+                && getName().equals(that.getName());
     }
 
     @Override
-    public int getSecuritySpecification()
-    {
+    public int getSecuritySpecification() {
         return securitySpecifications;
     }
 
     @Override
-    public @NonNull Named getSuperName()
-    {
+    public @NonNull Named getSuperName() {
         return superName;
     }
 
     @Override
-    public @NonNull LinkedHashSet<Named> getInterfaces()
-    {
+    public @NonNull LinkedHashSet<Named> getInterfaces() {
         return interfaces;
     }
 
     @Override
-    public @NonNull LinkedHashSet<MethodMetadata> getMethods()
-    {
+    public @NonNull LinkedHashSet<MethodMetadata> getMethods() {
         return methods;
     }
 
     @Override
-    public @NonNull LinkedHashSet<FieldMetadata> getFields()
-    {
+    public @NonNull LinkedHashSet<FieldMetadata> getFields() {
         return fields;
     }
 
     @Override
-    public @NonNull LinkedHashSet<RecordMetadata> getRecords()
-    {
+    public @NonNull LinkedHashSet<RecordMetadata> getRecords() {
         return records;
     }
 
     @Override
-    public @NonNull LinkedHashSet<ClassMetadata> getInnerClasses()
-    {
+    public @NonNull LinkedHashSet<ClassMetadata> getInnerClasses() {
         return innerClasses;
     }
 
     @Override
-    public @NonNull Named getSignature()
-    {
+    public @NonNull Named getSignature() {
         return signature;
     }
 
     @Override
-    public boolean isRecord()
-    {
+    public boolean isRecord() {
         return isRecord;
     }
 
     @Override
-    public @NonNull Named getOwner()
-    {
+    public @NonNull Named getOwner() {
         return owner;
     }
 
     @Override
-    public @NonNull Named getName()
-    {
+    public @NonNull Named getName() {
         return name;
     }
 }

--- a/core/src/main/java/org/parchmentmc/feather/metadata/ClassMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/ClassMetadataBuilder.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public final class ClassMetadataBuilder implements ClassMetadata {
     private Named superName = Named.empty();
@@ -306,11 +305,11 @@ public final class ClassMetadataBuilder implements ClassMetadata {
     public ClassMetadata build() {
         return new ImmutableClassMetadata(
                 superName.toImmutable(),
-                interfaces.stream().map(Named::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-                methods.stream().map(MethodMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-                fields.stream().map(FieldMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-                records.stream().map(RecordMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-                innerClasses.stream().map(ClassMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                interfaces.stream().map(Named::toImmutable).collect(CollectorUtils.toLinkedSet()),
+                methods.stream().map(MethodMetadata::toImmutable).collect(CollectorUtils.toLinkedSet()),
+                fields.stream().map(FieldMetadata::toImmutable).collect(CollectorUtils.toLinkedSet()),
+                records.stream().map(RecordMetadata::toImmutable).collect(CollectorUtils.toLinkedSet()),
+                innerClasses.stream().map(ClassMetadata::toImmutable).collect(CollectorUtils.toLinkedSet()),
                 owner.toImmutable(),
                 name.toImmutable(),
                 securitySpecifications,

--- a/core/src/main/java/org/parchmentmc/feather/metadata/ImmutableClassMetadata.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/ImmutableClassMetadata.java
@@ -33,7 +33,7 @@ final class ImmutableClassMetadata implements ClassMetadata {
         this.interfaces = new LinkedHashSet<>(interfaces);
         this.methods = new LinkedHashSet<>(methods);
         this.fields = new LinkedHashSet<>(fields);
-        this.records = records;
+        this.records = new LinkedHashSet<>(records);
         this.innerClasses = new LinkedHashSet<>(innerClasses);
         this.owner = owner;
         this.name = name;

--- a/core/src/main/java/org/parchmentmc/feather/metadata/MethodMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/MethodMetadataBuilder.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public final class MethodMetadataBuilder implements MethodMetadata {
     private Named owner = Named.empty();
@@ -313,7 +312,7 @@ public final class MethodMetadataBuilder implements MethodMetadata {
                 lambda,
                 bouncingTarget == null ? null : bouncingTarget.toImmutable(),
                 parent,
-                overrides.stream().map(Reference::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                overrides.stream().map(Reference::toImmutable).collect(CollectorUtils.toLinkedSet()),
                 name.toImmutable(),
                 securitySpecification,
                 descriptor.toImmutable(),

--- a/core/src/main/java/org/parchmentmc/feather/metadata/MethodMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/MethodMetadataBuilder.java
@@ -5,196 +5,181 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.parchmentmc.feather.named.Named;
 import org.parchmentmc.feather.named.NamedBuilder;
 import org.parchmentmc.feather.util.AccessFlag;
+import org.parchmentmc.feather.util.CollectorUtils;
 
-import java.util.*;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public final class MethodMetadataBuilder implements MethodMetadata
-{
-    private Named                          owner                 = Named.empty();
-    private boolean                        lambda                = false;
-    private BouncingTargetMetadata   bouncingTarget = null;
-    private LinkedHashSet<Reference> overrides      = Sets.newLinkedHashSet();
-    private Named                    name           = Named.empty();
-    private int                            securitySpecification = 0;
-    private Named                          descriptor            = Named.empty();
-    private Named                          signature             = Named.empty();
-    private int                            startLine             = 0;
-    private int                      endLine        = 0;
-    private Reference                parent         = null;
+public final class MethodMetadataBuilder implements MethodMetadata {
+    private Named owner = Named.empty();
+    private boolean lambda = false;
+    private BouncingTargetMetadata bouncingTarget = null;
+    private LinkedHashSet<Reference> overrides = Sets.newLinkedHashSet();
+    private Named name = Named.empty();
+    private int securitySpecification = 0;
+    private Named descriptor = Named.empty();
+    private Named signature = Named.empty();
+    private int startLine = 0;
+    private int endLine = 0;
+    private Reference parent = null;
 
-    private MethodMetadataBuilder()
-    {
+    private MethodMetadataBuilder() {
     }
 
-    public static MethodMetadataBuilder create(final MethodMetadata target)
-    {
+    public static MethodMetadataBuilder create(final MethodMetadata target) {
         if (target == null)
             return create();
 
         return create()
-                 .withOwner(target.getOwner())
-                 .withLambda(target.isLambda())
-                 .withBouncingTarget(target.getBouncingTarget().orElse(null))
-                 .withParent(target.getParent().orElse(null))
-                 .withOverrides(target.getOverrides())
-                 .withName(target.getName())
-                 .withSecuritySpecification(target.getSecuritySpecification())
-                 .withDescriptor(target.getDescriptor())
-                 .withSignature(target.getSignature())
-                 .withStartLine(target.getStartLine().orElse(0))
-                 .withEndLine(target.getEndLine().orElse(0));
+                .withOwner(target.getOwner())
+                .withLambda(target.isLambda())
+                .withBouncingTarget(target.getBouncingTarget().orElse(null))
+                .withParent(target.getParent().orElse(null))
+                .withOverrides(target.getOverrides())
+                .withName(target.getName())
+                .withSecuritySpecification(target.getSecuritySpecification())
+                .withDescriptor(target.getDescriptor())
+                .withSignature(target.getSignature())
+                .withStartLine(target.getStartLine().orElse(0))
+                .withEndLine(target.getEndLine().orElse(0));
     }
 
-    public MethodMetadataBuilder withEndLine(final int endLine)
-    {
+    public static MethodMetadataBuilder create() {
+        return new MethodMetadataBuilder();
+    }
+
+    public MethodMetadataBuilder withEndLine(final int endLine) {
         this.endLine = endLine;
         return this;
     }
 
-    public MethodMetadataBuilder withStartLine(final int startLine)
-    {
+    public MethodMetadataBuilder withStartLine(final int startLine) {
         this.startLine = startLine;
         return this;
     }
 
-    public MethodMetadataBuilder withSignature(Named signature)
-    {
+    public MethodMetadataBuilder withSignature(Named signature) {
         this.signature = signature;
         return this;
     }
 
-    public MethodMetadataBuilder withDescriptor(Named descriptor)
-    {
+    public MethodMetadataBuilder withDescriptor(Named descriptor) {
         this.descriptor = descriptor;
         return this;
     }
 
-    public MethodMetadataBuilder withSecuritySpecification(int securitySpecification)
-    {
+    public MethodMetadataBuilder withSecuritySpecification(int securitySpecification) {
         this.securitySpecification = securitySpecification;
         return this;
     }
 
-    public MethodMetadataBuilder withName(Named name)
-    {
+    public MethodMetadataBuilder withName(Named name) {
         this.name = name;
         return this;
     }
 
-    public MethodMetadataBuilder withOverrides(LinkedHashSet<Reference> overrides)
-    {
+    public MethodMetadataBuilder withOverrides(LinkedHashSet<Reference> overrides) {
         this.overrides = overrides;
         return this;
     }
 
-    public MethodMetadataBuilder withParent(final Reference parent)
-    {
+    public MethodMetadataBuilder withParent(final Reference parent) {
         this.parent = parent;
         return this;
     }
 
-    public MethodMetadataBuilder withBouncingTarget(BouncingTargetMetadata bouncingTarget)
-    {
+    public MethodMetadataBuilder withBouncingTarget(BouncingTargetMetadata bouncingTarget) {
         this.bouncingTarget = bouncingTarget;
         return this;
     }
 
-    public MethodMetadataBuilder withLambda(boolean lambda)
-    {
+    public MethodMetadataBuilder withLambda(boolean lambda) {
         this.lambda = lambda;
         return this;
     }
 
-    public MethodMetadataBuilder withOwner(Named owner)
-    {
+    public MethodMetadataBuilder withOwner(Named owner) {
         this.owner = owner;
         return this;
     }
 
-    public static MethodMetadataBuilder create()
-    {
-        return new MethodMetadataBuilder();
-    }
-
-    public MethodMetadataBuilder merge(final MethodMetadata source, final String schema)
-    {
+    public MethodMetadataBuilder merge(final MethodMetadata source, final String schema) {
         if (source == null)
             return this;
 
         this.owner = NamedBuilder.create(this.owner)
-                       .merge(source.getOwner())
-                       .build();
+                .merge(source.getOwner())
+                .build();
         this.lambda = this.lambda || source.isLambda();
         this.bouncingTarget = BouncingTargetMetadataBuilder.create(this.bouncingTarget)
-                                .merge(source.getBouncingTarget().orElse(null))
-                                .build();
+                .merge(source.getBouncingTarget().orElse(null))
+                .build();
 
         final Map<Reference, Reference> schemadLocalOverrides =
-          this.overrides.stream().collect(Collectors.toMap(
-            mr -> ReferenceBuilder.create()
-                    .withName(NamedBuilder.create()
-                                .with(schema, mr.getName().getName(schema).orElse(""))
-                    )
-                    .withOwner(NamedBuilder.create()
-                                 .with(schema, mr.getOwner().getName(schema).orElse(""))
-                    )
-                    .withDescriptor(NamedBuilder.create()
-                                      .with(schema, mr.getDescriptor().getName(schema).orElse(""))
-                    )
-                    .withSignature(NamedBuilder.create()
-                                     .with(schema, mr.getSignature().getName(schema).orElse(""))
-                    )
-                    .build(),
-            Function.identity(),
-            (t, i) -> t
-          ));
+                this.overrides.stream().collect(CollectorUtils.toLinkedMap(
+                        mr -> ReferenceBuilder.create()
+                                .withName(NamedBuilder.create()
+                                        .with(schema, mr.getName().getName(schema).orElse(""))
+                                )
+                                .withOwner(NamedBuilder.create()
+                                        .with(schema, mr.getOwner().getName(schema).orElse(""))
+                                )
+                                .withDescriptor(NamedBuilder.create()
+                                        .with(schema, mr.getDescriptor().getName(schema).orElse(""))
+                                )
+                                .withSignature(NamedBuilder.create()
+                                        .with(schema, mr.getSignature().getName(schema).orElse(""))
+                                )
+                                .build(),
+                        Function.identity(),
+                        (t, i) -> t
+                ));
 
         final Map<Reference, Reference> schemadSoureOverrides =
-          source.getOverrides().stream().collect(
-            Collectors.toMap(
-              mr -> ReferenceBuilder.create()
-                      .withName(NamedBuilder.create()
-                                  .with(schema, mr.getName().getName(schema).orElse(""))
-                      )
-                      .withOwner(NamedBuilder.create()
-                                   .with(schema, mr.getOwner().getName(schema).orElse(""))
-                      )
-                      .withDescriptor(NamedBuilder.create()
-                                        .with(schema, mr.getDescriptor().getName(schema).orElse(""))
-                      )
-                      .withSignature(NamedBuilder.create()
-                                       .with(schema, mr.getSignature().getName(schema).orElse(""))
-                      )
-                      .build(),
-              Function.identity(),
-              (t, i) -> t
-            ));
+                source.getOverrides().stream().collect(
+                        CollectorUtils.toLinkedMap(
+                                mr -> ReferenceBuilder.create()
+                                        .withName(NamedBuilder.create()
+                                                .with(schema, mr.getName().getName(schema).orElse(""))
+                                        )
+                                        .withOwner(NamedBuilder.create()
+                                                .with(schema, mr.getOwner().getName(schema).orElse(""))
+                                        )
+                                        .withDescriptor(NamedBuilder.create()
+                                                .with(schema, mr.getDescriptor().getName(schema).orElse(""))
+                                        )
+                                        .withSignature(NamedBuilder.create()
+                                                .with(schema, mr.getSignature().getName(schema).orElse(""))
+                                        )
+                                        .build(),
+                                Function.identity(),
+                                (t, i) -> t
+                        ));
 
         this.overrides = new LinkedHashSet<>();
-        for (final Reference keyReference : schemadLocalOverrides.keySet())
-        {
-            if (!schemadSoureOverrides.containsKey(keyReference))
-            {
+        for (final Reference keyReference : schemadLocalOverrides.keySet()) {
+            if (!schemadSoureOverrides.containsKey(keyReference)) {
                 this.overrides.add(schemadLocalOverrides.get(keyReference));
-            }
-            else
-            {
+            } else {
                 this.overrides.add(
-                  ReferenceBuilder.create(schemadLocalOverrides.get(keyReference))
-                    .merge(schemadSoureOverrides.get(keyReference))
-                    .build()
+                        ReferenceBuilder.create(schemadLocalOverrides.get(keyReference))
+                                .merge(schemadSoureOverrides.get(keyReference))
+                                .build()
                 );
             }
         }
         schemadSoureOverrides.keySet().stream()
-          .filter(mr -> !schemadLocalOverrides.containsKey(mr))
-          .forEach(mr -> this.overrides.add(schemadSoureOverrides.get(mr)));
+                .filter(mr -> !schemadLocalOverrides.containsKey(mr))
+                .forEach(mr -> this.overrides.add(schemadSoureOverrides.get(mr)));
 
         this.name = NamedBuilder.create(this.name)
-                      .merge(source.getName())
-                      .build();
+                .merge(source.getName())
+                .build();
 
         final EnumSet<AccessFlag> thisAccessFlags = AccessFlag.getAccessFlags(this.securitySpecification);
         final EnumSet<AccessFlag> sourceAccessFlags = AccessFlag.getAccessFlags(source.getSecuritySpecification());
@@ -206,11 +191,11 @@ public final class MethodMetadataBuilder implements MethodMetadata
         this.securitySpecification = AccessFlag.toSecuritySpecification(mergedFlags);
 
         this.descriptor = NamedBuilder.create(this.descriptor)
-                            .merge(source.getDescriptor())
-                            .build();
+                .merge(source.getDescriptor())
+                .build();
         this.signature = NamedBuilder.create(this.signature)
-                           .merge(source.getSignature())
-                           .build();
+                .merge(source.getSignature())
+                .build();
 
         this.startLine = source.getStartLine().orElse(this.startLine);
         this.endLine = source.getEndLine().orElse(this.endLine);
@@ -219,80 +204,69 @@ public final class MethodMetadataBuilder implements MethodMetadata
     }
 
     @Override
-    public int hashCode()
-    {
+    public int hashCode() {
         return Objects.hash(getOwner(),
-          isLambda(),
-          getBouncingTarget(),
-          getOverrides(),
-          getName(),
-          getSecuritySpecification(),
-          getDescriptor(),
-          getSignature(),
-          getStartLine(),
-          getEndLine());
+                isLambda(),
+                getBouncingTarget(),
+                getOverrides(),
+                getName(),
+                getSecuritySpecification(),
+                getDescriptor(),
+                getSignature(),
+                getStartLine(),
+                getEndLine());
     }
 
     @Override
-    public boolean equals(final Object o)
-    {
-        if (this == o)
-        {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof MethodMetadataBuilder))
-        {
+        if (!(o instanceof MethodMetadataBuilder)) {
             return false;
         }
         final MethodMetadataBuilder builder = (MethodMetadataBuilder) o;
         return isLambda() == builder.isLambda()
-                 && getSecuritySpecification() == builder.getSecuritySpecification()
-                 && getStartLine() == builder.getStartLine()
-                 && getEndLine() == builder.getEndLine()
-                 && getOwner().equals(builder.getOwner())
-                 && getBouncingTarget().equals(builder.getBouncingTarget())
-                 && getOverrides().equals(builder.getOverrides())
-                 && getName().equals(builder.getName())
-                 && getDescriptor().equals(builder.getDescriptor())
-                 && getSignature().equals(builder.getSignature());
+                && getSecuritySpecification() == builder.getSecuritySpecification()
+                && getStartLine() == builder.getStartLine()
+                && getEndLine() == builder.getEndLine()
+                && getOwner().equals(builder.getOwner())
+                && getBouncingTarget().equals(builder.getBouncingTarget())
+                && getOverrides().equals(builder.getOverrides())
+                && getName().equals(builder.getName())
+                && getDescriptor().equals(builder.getDescriptor())
+                && getSignature().equals(builder.getSignature());
     }
 
     @Override
-    public @NonNull Named getOwner()
-    {
+    public @NonNull Named getOwner() {
         return owner;
     }
 
     @Override
-    public boolean isLambda()
-    {
+    public boolean isLambda() {
         return lambda;
     }
 
     @Override
-    public Optional<BouncingTargetMetadata> getBouncingTarget()
-    {
+    public Optional<BouncingTargetMetadata> getBouncingTarget() {
         return Optional.ofNullable(bouncingTarget);
     }
 
     @Override
-    public Optional<Reference> getParent()
-    {
+    public Optional<Reference> getParent() {
         return Optional.ofNullable(parent);
     }
 
     @Override
     @NonNull
-    public LinkedHashSet<Reference> getOverrides()
-    {
+    public LinkedHashSet<Reference> getOverrides() {
         return overrides;
     }
 
     @Override
-    public @NonNull Optional<Integer> getStartLine()
-    {
-        if (startLine <= 0)
-        {
+    public @NonNull Optional<Integer> getStartLine() {
+        if (startLine <= 0) {
             return Optional.empty();
         }
 
@@ -300,10 +274,8 @@ public final class MethodMetadataBuilder implements MethodMetadata
     }
 
     @Override
-    public @NonNull Optional<Integer> getEndLine()
-    {
-        if (endLine <= 0)
-        {
+    public @NonNull Optional<Integer> getEndLine() {
+        if (endLine <= 0) {
             return Optional.empty();
         }
 
@@ -311,49 +283,43 @@ public final class MethodMetadataBuilder implements MethodMetadata
     }
 
     @Override
-    public @NonNull Named getName()
-    {
+    public @NonNull Named getName() {
         return name;
     }
 
     @Override
-    public int getSecuritySpecification()
-    {
+    public int getSecuritySpecification() {
         return securitySpecification;
     }
 
     @Override
-    public @NonNull Named getDescriptor()
-    {
+    public @NonNull Named getDescriptor() {
         return descriptor;
     }
 
     @Override
-    public @NonNull Named getSignature()
-    {
+    public @NonNull Named getSignature() {
         return signature;
     }
 
     @Override
-    public @NonNull MethodMetadata toImmutable()
-    {
+    public @NonNull MethodMetadata toImmutable() {
         return build();
     }
 
-    public MethodMetadata build()
-    {
+    public MethodMetadata build() {
         return new ImmutableMethodMetadata(
-          owner.toImmutable(),
-          lambda,
-          bouncingTarget == null ? null : bouncingTarget.toImmutable(),
-          parent,
-          overrides.stream().map(Reference::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
-          name.toImmutable(),
-          securitySpecification,
-          descriptor.toImmutable(),
-          signature.toImmutable(),
-          startLine,
-          endLine
+                owner.toImmutable(),
+                lambda,
+                bouncingTarget == null ? null : bouncingTarget.toImmutable(),
+                parent,
+                overrides.stream().map(Reference::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new)),
+                name.toImmutable(),
+                securitySpecification,
+                descriptor.toImmutable(),
+                signature.toImmutable(),
+                startLine,
+                endLine
         );
     }
 }

--- a/core/src/main/java/org/parchmentmc/feather/metadata/SourceMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/SourceMetadataBuilder.java
@@ -10,7 +10,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public final class SourceMetadataBuilder implements SourceMetadata {
     private SimpleVersion specVersion = SimpleVersion.of(1, 0, 0);
@@ -105,7 +104,7 @@ public final class SourceMetadataBuilder implements SourceMetadata {
         return new ImmutableSourceMetadata(
                 specVersion,
                 minecraftVersion,
-                classes.stream().map(ClassMetadata::toImmutable).collect(Collectors.toCollection(LinkedHashSet::new))
+                classes.stream().map(ClassMetadata::toImmutable).collect(CollectorUtils.toLinkedSet())
         );
     }
 

--- a/core/src/main/java/org/parchmentmc/feather/metadata/SourceMetadataBuilder.java
+++ b/core/src/main/java/org/parchmentmc/feather/metadata/SourceMetadataBuilder.java
@@ -3,6 +3,7 @@ package org.parchmentmc.feather.metadata;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.parchmentmc.feather.named.Named;
 import org.parchmentmc.feather.named.NamedBuilder;
+import org.parchmentmc.feather.util.CollectorUtils;
 import org.parchmentmc.feather.util.SimpleVersion;
 
 import java.util.LinkedHashSet;
@@ -53,14 +54,14 @@ public final class SourceMetadataBuilder implements SourceMetadata {
             return this;
 
         final Map<Named, ClassMetadata> schemadLocalInnerClasses = this.classes
-                .stream().collect(Collectors.toMap(
+                .stream().collect(CollectorUtils.toLinkedMap(
                         fm -> NamedBuilder.create()
                                 .with(mergingSchema, fm.getName().getName(mergingSchema).orElse(""))
                                 .build(),
                         Function.identity()
                 ));
         final Map<Named, ClassMetadata> schemadSourceInnerClasses = source.getClasses()
-                .stream().collect(Collectors.toMap(
+                .stream().collect(CollectorUtils.toLinkedMap(
                         fm -> NamedBuilder.create()
                                 .with(mergingSchema, fm.getName().getName(mergingSchema).orElse(""))
                                 .build(),

--- a/core/src/main/java/org/parchmentmc/feather/util/CollectorUtils.java
+++ b/core/src/main/java/org/parchmentmc/feather/util/CollectorUtils.java
@@ -1,0 +1,168 @@
+package org.parchmentmc.feather.util;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public final class CollectorUtils {
+
+    private CollectorUtils() {
+        throw new IllegalStateException("Can not instantiate an instance of: CollectorUtils. This is a utility class");
+    }
+
+    /**
+     * Returns a {@code Collector} that accumulates elements into a
+     * {@code Map} whose keys and values are the result of applying the provided
+     * mapping functions to the input elements.
+     *
+     * <p>If the mapped keys contains duplicates (according to
+     * {@link Object#equals(Object)}), an {@code IllegalStateException} is
+     * thrown when the collection operation is performed.  If the mapped keys
+     * may have duplicates, use {@link Collectors#toMap(Function, Function, BinaryOperator)}
+     * instead.
+     *
+     * @apiNote
+     * It is common for either the key or the value to be the input elements.
+     * In this case, the utility method
+     * {@link java.util.function.Function#identity()} may be helpful.
+     * For example, the following produces a {@code Map} mapping
+     * students to their grade point average:
+     * <pre>{@code
+     *     Map<Student, Double> studentToGPA
+     *         students.stream().collect(toMap(Functions.identity(),
+     *                                         student -> computeGPA(student)));
+     * }</pre>
+     * And the following produces a {@code Map} mapping a unique identifier to
+     * students:
+     * <pre>{@code
+     *     Map<String, Student> studentIdToStudent
+     *         students.stream().collect(toMap(Student::getId,
+     *                                         Functions.identity());
+     * }</pre>
+     *
+     * @implNote
+     * The returned {@code Collector} is not concurrent.  For parallel stream
+     * pipelines, the {@code combiner} function operates by merging the keys
+     * from one map into another, which can be an expensive operation.  If it is
+     * not required that results are inserted into the {@code Map} in encounter
+     * order, using {@link Collectors#toConcurrentMap(Function, Function)}
+     * may offer better parallel performance.
+     * <p>
+     * The returned {@code Map} is linked and will retain its insertion order.
+     *
+     * @param <T> the type of the input elements
+     * @param <K> the output type of the key mapping function
+     * @param <U> the output type of the value mapping function
+     * @param keyMapper a mapping function to produce keys
+     * @param valueMapper a mapping function to produce values
+     * @return a {@code Collector} which collects elements into a {@code Map}
+     * whose keys and values are the result of applying mapping functions to
+     * the input elements
+     *
+     * @see Collectors#toMap(Function, Function, BinaryOperator)
+     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @see Collectors#toConcurrentMap(Function, Function)
+     */
+    public static <T, K, U> Collector<T, ?, Map<K,U>> toLinkedMap(Function<? super T, ? extends K> keyMapper,
+                                                                  Function<? super T, ? extends U> valueMapper) {
+        return Collectors.toMap(keyMapper, valueMapper, throwingMerger(), LinkedHashMap::new);
+    }
+
+    /**
+     * Returns a {@code Collector} that accumulates elements into a
+     * {@code Map} whose keys and values are the result of applying the provided
+     * mapping functions to the input elements.
+     *
+     * <p>If the mapped
+     * keys contains duplicates (according to {@link Object#equals(Object)}),
+     * the value mapping function is applied to each equal element, and the
+     * results are merged using the provided merging function.
+     *
+     * @apiNote
+     * There are multiple ways to deal with collisions between multiple elements
+     * mapping to the same key.  The other forms of {@code toMap} simply use
+     * a merge function that throws unconditionally, but you can easily write
+     * more flexible merge policies.  For example, if you have a stream
+     * of {@code Person}, and you want to produce a "phone book" mapping name to
+     * address, but it is possible that two persons have the same name, you can
+     * do as follows to gracefully deals with these collisions, and produce a
+     * {@code Map} mapping names to a concatenated list of addresses:
+     * <pre>{@code
+     *     Map<String, String> phoneBook
+     *         people.stream().collect(toMap(Person::getName,
+     *                                       Person::getAddress,
+     *                                       (s, a) -> s + ", " + a));
+     * }</pre>
+     *
+     * @implNote
+     * The returned {@code Collector} is not concurrent.  For parallel stream
+     * pipelines, the {@code combiner} function operates by merging the keys
+     * from one map into another, which can be an expensive operation.  If it is
+     * not required that results are merged into the {@code Map} in encounter
+     * order, using {@link Collectors#toConcurrentMap(Function, Function, BinaryOperator)}
+     * may offer better parallel performance.
+     * <p>
+     * The returned {@code Map} is linked and will retain its insertion order.
+     *
+     * @param <T> the type of the input elements
+     * @param <K> the output type of the key mapping function
+     * @param <U> the output type of the value mapping function
+     * @param keyMapper a mapping function to produce keys
+     * @param valueMapper a mapping function to produce values
+     * @param mergeFunction a merge function, used to resolve collisions between
+     *                      values associated with the same key, as supplied
+     *                      to {@link Map#merge(Object, Object, BiFunction)}
+     * @return a {@code Collector} which collects elements into a {@code Map}
+     * whose keys are the result of applying a key mapping function to the input
+     * elements, and whose values are the result of applying a value mapping
+     * function to all input elements equal to the key and combining them
+     * using the merge function
+     *
+     * @see Collectors#toMap(Function, Function)
+     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @see Collectors#toConcurrentMap(Function, Function, BinaryOperator)
+     */
+    public static <T, K, U>
+    Collector<T, ?, Map<K,U>> toLinkedMap(Function<? super T, ? extends K> keyMapper,
+                                    Function<? super T, ? extends U> valueMapper,
+                                    BinaryOperator<U> mergeFunction) {
+        return Collectors.toMap(keyMapper, valueMapper, mergeFunction, LinkedHashMap::new);
+    }
+
+    /**
+     * Returns a merge function, suitable for use in
+     * {@link Map#merge(Object, Object, BiFunction) Map.merge()} or
+     * {@link Collectors#toMap(Function, Function, BinaryOperator) toMap()}, which always
+     * throws {@code IllegalStateException}.  This can be used to enforce the
+     * assumption that the elements being collected are distinct.
+     *
+     * @param <T> the type of input arguments to the merge function
+     * @return a merge function which always throw {@code IllegalStateException}
+     */
+    private static <T> BinaryOperator<T> throwingMerger() {
+        return (u,v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); };
+    }
+
+    /**
+     * Returns a {@code Collector} that accumulates the input elements into a
+     * new {@code Set}. There are no guarantees on the type, mutability,
+     * serializability, or thread-safety of the {@code Set} returned, however insertion
+     * order is maintained.
+     *
+     * @param <T> the type of the input elements
+     * @return a {@code Collector} which collects all the input elements into a
+     * {@code Set} maintaining insertion order
+     */
+    public static <T> Collector<T, ?, Set<T>> toLinkedSet() {
+        return Collectors.toCollection(LinkedHashSet::new);
+    }
+}

--- a/core/src/main/java/org/parchmentmc/feather/util/CollectorUtils.java
+++ b/core/src/main/java/org/parchmentmc/feather/util/CollectorUtils.java
@@ -1,7 +1,5 @@
 package org.parchmentmc.feather.util;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -22,7 +20,8 @@ public final class CollectorUtils {
     /**
      * Returns a {@code Collector} that accumulates elements into a
      * {@code Map} whose keys and values are the result of applying the provided
-     * mapping functions to the input elements.
+     * mapping functions to the input elements, and which retains the insertion order of
+     * accumulated elements.
      *
      * <p>If the mapped keys contains duplicates (according to
      * {@link Object#equals(Object)}), an {@code IllegalStateException} is
@@ -30,34 +29,9 @@ public final class CollectorUtils {
      * may have duplicates, use {@link Collectors#toMap(Function, Function, BinaryOperator)}
      * instead.
      *
-     * @apiNote
-     * It is common for either the key or the value to be the input elements.
-     * In this case, the utility method
-     * {@link java.util.function.Function#identity()} may be helpful.
-     * For example, the following produces a {@code Map} mapping
-     * students to their grade point average:
-     * <pre>{@code
-     *     Map<Student, Double> studentToGPA
-     *         students.stream().collect(toMap(Functions.identity(),
-     *                                         student -> computeGPA(student)));
-     * }</pre>
-     * And the following produces a {@code Map} mapping a unique identifier to
-     * students:
-     * <pre>{@code
-     *     Map<String, Student> studentIdToStudent
-     *         students.stream().collect(toMap(Student::getId,
-     *                                         Functions.identity());
-     * }</pre>
-     *
-     * @implNote
-     * The returned {@code Collector} is not concurrent.  For parallel stream
-     * pipelines, the {@code combiner} function operates by merging the keys
-     * from one map into another, which can be an expensive operation.  If it is
-     * not required that results are inserted into the {@code Map} in encounter
-     * order, using {@link Collectors#toConcurrentMap(Function, Function)}
-     * may offer better parallel performance.
-     * <p>
-     * The returned {@code Map} is linked and will retain its insertion order.
+     * <p>This method behaves equivalently to {@link Collectors#toMap(Function, Function)}
+     * with the notable difference that the returned {@link Map} retains the insertion order
+     * of accumulated elements.
      *
      * @param <T> the type of the input elements
      * @param <K> the output type of the key mapping function
@@ -66,11 +40,11 @@ public final class CollectorUtils {
      * @param valueMapper a mapping function to produce values
      * @return a {@code Collector} which collects elements into a {@code Map}
      * whose keys and values are the result of applying mapping functions to
-     * the input elements
+     * the input elements, and which retains the insertion order of
+     * accumulated elements
      *
-     * @see Collectors#toMap(Function, Function, BinaryOperator)
-     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
-     * @see Collectors#toConcurrentMap(Function, Function)
+     * @see #toLinkedMap(Function, Function, BinaryOperator)
+     * @see Collectors#toMap(Function, Function)
      */
     public static <T, K, U> Collector<T, ?, Map<K,U>> toLinkedMap(Function<? super T, ? extends K> keyMapper,
                                                                   Function<? super T, ? extends U> valueMapper) {
@@ -80,38 +54,17 @@ public final class CollectorUtils {
     /**
      * Returns a {@code Collector} that accumulates elements into a
      * {@code Map} whose keys and values are the result of applying the provided
-     * mapping functions to the input elements.
+     * mapping functions to the input elements, and which retains the insertion order of
+     * accumulated elements.
      *
      * <p>If the mapped
      * keys contains duplicates (according to {@link Object#equals(Object)}),
      * the value mapping function is applied to each equal element, and the
      * results are merged using the provided merging function.
      *
-     * @apiNote
-     * There are multiple ways to deal with collisions between multiple elements
-     * mapping to the same key.  The other forms of {@code toMap} simply use
-     * a merge function that throws unconditionally, but you can easily write
-     * more flexible merge policies.  For example, if you have a stream
-     * of {@code Person}, and you want to produce a "phone book" mapping name to
-     * address, but it is possible that two persons have the same name, you can
-     * do as follows to gracefully deals with these collisions, and produce a
-     * {@code Map} mapping names to a concatenated list of addresses:
-     * <pre>{@code
-     *     Map<String, String> phoneBook
-     *         people.stream().collect(toMap(Person::getName,
-     *                                       Person::getAddress,
-     *                                       (s, a) -> s + ", " + a));
-     * }</pre>
-     *
-     * @implNote
-     * The returned {@code Collector} is not concurrent.  For parallel stream
-     * pipelines, the {@code combiner} function operates by merging the keys
-     * from one map into another, which can be an expensive operation.  If it is
-     * not required that results are merged into the {@code Map} in encounter
-     * order, using {@link Collectors#toConcurrentMap(Function, Function, BinaryOperator)}
-     * may offer better parallel performance.
-     * <p>
-     * The returned {@code Map} is linked and will retain its insertion order.
+     * <p>This method behaves equivalently to {@link Collectors#toMap(Function, Function, BinaryOperator)}
+     * with the notable difference that the returned {@link Map} retains the insertion order
+     * of accumulated elements.
      *
      * @param <T> the type of the input elements
      * @param <K> the output type of the key mapping function
@@ -125,11 +78,10 @@ public final class CollectorUtils {
      * whose keys are the result of applying a key mapping function to the input
      * elements, and whose values are the result of applying a value mapping
      * function to all input elements equal to the key and combining them
-     * using the merge function
+     * using the merge function, and which retains the insertion order of
+     * accumulated elements
      *
-     * @see Collectors#toMap(Function, Function)
-     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
-     * @see Collectors#toConcurrentMap(Function, Function, BinaryOperator)
+     * @see Collectors#toMap(Function, Function, BinaryOperator)
      */
     public static <T, K, U>
     Collector<T, ?, Map<K,U>> toLinkedMap(Function<? super T, ? extends K> keyMapper,
@@ -162,7 +114,7 @@ public final class CollectorUtils {
      * @return a {@code Collector} which collects all the input elements into a
      * {@code Set} maintaining insertion order
      */
-    public static <T> Collector<T, ?, Set<T>> toLinkedSet() {
+    public static <T> Collector<T, ?, LinkedHashSet<T>> toLinkedSet() {
         return Collectors.toCollection(LinkedHashSet::new);
     }
 }

--- a/io-proguard/src/main/java/org/parchmentmc/feather/io/proguard/MetadataProguardParser.java
+++ b/io-proguard/src/main/java/org/parchmentmc/feather/io/proguard/MetadataProguardParser.java
@@ -166,7 +166,7 @@ public final class MetadataProguardParser {
                         .stream()
                         .filter(classMetadataBuilder -> classMetadataBuilder.getOwner().isEmpty())
                         .map(ClassMetadataBuilder::build)
-                        .collect(Collectors.toCollection(LinkedHashSet::new))
+                        .collect(CollectorUtils.toLinkedSet())
                 )
                 .build();
     }

--- a/io-proguard/src/main/java/org/parchmentmc/feather/io/proguard/MetadataProguardParser.java
+++ b/io-proguard/src/main/java/org/parchmentmc/feather/io/proguard/MetadataProguardParser.java
@@ -3,6 +3,7 @@ package org.parchmentmc.feather.io.proguard;
 import org.parchmentmc.feather.metadata.*;
 import org.parchmentmc.feather.named.Named;
 import org.parchmentmc.feather.named.NamedBuilder;
+import org.parchmentmc.feather.util.CollectorUtils;
 import org.parchmentmc.feather.utils.RemapHelper;
 
 import java.io.*;
@@ -145,7 +146,7 @@ public final class MetadataProguardParser {
     private static SourceMetadata adaptInnerOuterClassList(final SourceMetadata sourceMetadata) {
         final Map<Named, ClassMetadataBuilder> namedClassMetadataMap = sourceMetadata.getClasses()
                 .stream()
-                .collect(Collectors.toMap(
+                .collect(CollectorUtils.toLinkedMap(
                         WithName::getName,
                         ClassMetadataBuilder::create
                 ));
@@ -211,7 +212,7 @@ public final class MetadataProguardParser {
         return ClassMetadataBuilder.create(classMetadata)
                 .withInnerClasses(classMetadata.getInnerClasses().stream()
                         .map(inner -> adaptTypeDescriptors(inner, mojToObfClassMap))
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withMethods(classMetadata.getMethods().stream()
                         .map(method -> {
                             final String mojangName = method.getDescriptor().getMojangName().orElseThrow(() -> new IllegalStateException("Missing mojang descriptor"));
@@ -222,7 +223,7 @@ public final class MetadataProguardParser {
                                             .withObfuscated(RemapHelper.remapMethodDescriptor(mojangName, mojToObfClassMap::get))
                                     );
                         })
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withFields(classMetadata.getFields().stream()
                         .map(field -> {
                             final String mojangName = field.getDescriptor().getMojangName().orElseThrow(() -> new IllegalStateException("Missing mojang type."));
@@ -233,7 +234,7 @@ public final class MetadataProguardParser {
                                             .withObfuscated(RemapHelper.remapTypeDescriptor(mojangName, mojToObfClassMap::get))
                                     );
                         })
-                        .collect(Collectors.toSet()));
+                        .collect(CollectorUtils.toLinkedSet()));
     }
 
     /**


### PR DESCRIPTION
Fixes issues with record entries and fields not matching up in order.